### PR TITLE
Updates to build configuration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,12 +24,12 @@ class get_pybind_include(object):
 
 
 ext_modules = [
-    Pybind11Extension("cogaps",
-        ["src/bindings.cpp"],
-        # Example: passing in the version to the compiled code
-        define_macros = [('VERSION_INFO', __version__)],
-        ),
-    Extension(
+    # Pybind11Extension("cogaps",
+    #     ["src/bindings.cpp"],
+    #     # Example: passing in the version to the compiled code
+    #     define_macros = [('VERSION_INFO', __version__)],
+    #     ),
+    Pybind11Extension(
         name='cogaps',
         sources=[
             'src/bindings.cpp',
@@ -63,7 +63,7 @@ ext_modules = [
             # Path to pybind11 headers
             get_pybind_include(),
             get_pybind_include(user=True),
-            'src/Rpackage/src/include'
+            './src/Rpackage/src/include/'
         ],
         language='c++'
     ),
@@ -102,16 +102,17 @@ class BuildExt(build_ext):
     """A custom build extension for adding compiler-specific options."""
     c_opts = {
         'msvc': ['/EHsc'],
-        'unix': ["-I Rpackage/src/include -nostdlib -undefined dynamic_lookup"],
+        'unix': [],
     }
 
     if sys.platform == 'darwin':
-        c_opts['unix'] += ['-stdlib=libc++', '-mmacosx-version-min=10.7']
+        c_opts['unix'] += ['-stdlib=libc++', '-mmacosx-version-min=10.9']
 
     def build_extensions(self):
         ct = self.compiler.compiler_type
         opts = self.c_opts.get(ct, [])
-        opts.append("-I Rpackage/src/include -nostdlib -undefined dynamic_lookup")
+        opts.append("-mmacosx-version-min=10.9")
+        opts.append("-I src/Rpackage/src/include/*")
         if ct == 'unix':
             opts.append('-DVERSION_INFO="%s"' % self.distribution.get_version())
             opts.append(cpp_flag(self.compiler))
@@ -128,12 +129,13 @@ setup(
     version=__version__,
     author='Thomas Sherman',
     author_email='tomsherman159@gmail.com',
-    url='https://github.com/FertigLab/Cogaps_PY',
+    url='https://github.com/FertigLab/pycogaps',
     description='Non-Negative Matrix Factorization Algorithm',
     long_description='',
     ext_modules=ext_modules,
     install_requires=['pybind11>=2.2'],
     cmdclass={'build_ext': BuildExt},
     zip_safe=False,
-    # extra_compile_args=["-I src/Rpackage/src/include", "-nostdlib" "-undefined dynamic_lookup"]
+    language="c++",
+   # extra_compile_args=["-I src/Rpackage/src/include", "-nostdlib" "-undefined dynamic_lookup"],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
-from setuptools import setup, Extension
+from setuptools import setup
 from setuptools.command.build_ext import build_ext
 import sys
-import sysconfig
 import setuptools
 
 from pybind11.setup_helpers import Pybind11Extension, build_ext
@@ -137,5 +136,4 @@ setup(
     cmdclass={'build_ext': BuildExt},
     zip_safe=False,
     language="c++",
-   # extra_compile_args=["-I src/Rpackage/src/include", "-nostdlib" "-undefined dynamic_lookup"],
 )

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -1,16 +1,25 @@
-#include "Rpackage/src/GapsRunner.h"
-#include "Rpackage/src/utils/GlobalConfig.h"
-
+//#include "Rpackage/src/GapsRunner.h"
+//#include "Rpackage/src/utils/GlobalConfig.h"
+//#include "Rpackage/src/GapsParameters.h"
+//#include "Rpackage/src/GapsResult.h"
+//#include "Rpackage/src/math/Random.h"
+// TODO: resolve this issue!! It can't find the boost library
+#include "Rpackage/src/include/*"
 #include <pybind11/pybind11.h>
-
+#include <iostream>
+#define STRINGIFY(x) #x
+#define MACRO_STRINGIFY(x) STRINGIFY(x)
 namespace py = pybind11;
 
 float runCogaps(const std::string &path)
 {
-    GapsParameters params(path);
-    GapsRandomState randState(params.seed);
-    GapsResult result(gaps::run(path, params, std::string(), &randState));
-    return result.meanChiSq;
+//    GapsParameters params(path);
+//    GapsRandomState randState(params.seed);
+//    GapsResult result(gaps::run(path, params, std::string(), &randState));
+
+//    return result.meanChiSq;
+    std::cout<<"we did it joe";
+    return 0;
 }
 
 PYBIND11_MODULE(cogaps, m)

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -15,10 +15,7 @@ float runCogaps(const std::string &path)
     GapsParameters params(path);
     GapsRandomState randState(params.seed);
     GapsResult result(gaps::run(path, params, std::string(), &randState));
-
     return result.meanChiSq;
-    std::cout<<"we did it joe";
-    return 0;
 }
 
 PYBIND11_MODULE(cogaps, m)

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -1,10 +1,9 @@
-//#include "Rpackage/src/GapsRunner.h"
-//#include "Rpackage/src/utils/GlobalConfig.h"
-//#include "Rpackage/src/GapsParameters.h"
-//#include "Rpackage/src/GapsResult.h"
-//#include "Rpackage/src/math/Random.h"
-// TODO: resolve this issue!! It can't find the boost library
-#include "Rpackage/src/include/*"
+#include "Rpackage/src/GapsRunner.h"
+#include "Rpackage/src/utils/GlobalConfig.h"
+#include "Rpackage/src/GapsParameters.h"
+#include "Rpackage/src/GapsResult.h"
+#include "Rpackage/src/math/Random.h"
+
 #include <pybind11/pybind11.h>
 #include <iostream>
 #define STRINGIFY(x) #x
@@ -13,11 +12,11 @@ namespace py = pybind11;
 
 float runCogaps(const std::string &path)
 {
-//    GapsParameters params(path);
-//    GapsRandomState randState(params.seed);
-//    GapsResult result(gaps::run(path, params, std::string(), &randState));
+    GapsParameters params(path);
+    GapsRandomState randState(params.seed);
+    GapsResult result(gaps::run(path, params, std::string(), &randState));
 
-//    return result.meanChiSq;
+    return result.meanChiSq;
     std::cout<<"we did it joe";
     return 0;
 }

--- a/testing.py
+++ b/testing.py
@@ -1,0 +1,10 @@
+'''
+a script for testing the python interface to cogaps
+jeanette johnson 6/14/21
+before running:
+navigate to your pycogaps direcotry and run 'pip install .'
+'''
+import cogaps
+
+cogaps.runCogaps("./data/GIST.csv")
+


### PR DESCRIPTION
Makes some small changes needed to compile c++ library with the correct [include] options from setup.py script. Includes a stub testing file to invoke the binding method, cogaps.runCogaps("path"). Should work out of the box now, at least on mac os.

I think most of these changes were necessary only because of updates to the pybind11 package.